### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "phpunit/phpunit": "^8.0",
-        "facebook/webdriver": "^1.7"
+        "php-webdriver/webdriver": "^1.7"
     },
     "require-dev": {
         "christophwurst/nextcloud": "^15.0"


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned.